### PR TITLE
a small cleanup

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -4,9 +4,6 @@ plugins {
     kotlin("android")
 }
 
-group "com.darkrockstudios.libraries.mpfilepicker"
-version "1.0-SNAPSHOT"
-
 repositories {
     mavenCentral()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,3 @@
-group "com.darkrockstudios.libraries.mpfilepicker"
-version "1.0-SNAPSHOT"
-
 allprojects {
     repositories {
         google()

--- a/desktopExample/build.gradle.kts
+++ b/desktopExample/build.gradle.kts
@@ -5,10 +5,6 @@ plugins {
     id("org.jetbrains.compose")
 }
 
-group = "com.darkrockstudios.libraries.mpfilepicker"
-version = "1.0-SNAPSHOT"
-
-
 kotlin {
     jvm {
         compilations.all {


### PR DESCRIPTION
writting `version "1.0-SNAPSHOT"` has no effect, so I deleted them

`version = "1.0-SNAPSHOT"` does have effect but I though it is useless so I removed it. Less code = less problems