### PR TITLE
fix random crashes on JVM

### DIFF
--- a/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/DesktopFilePicker.kt
+++ b/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/DesktopFilePicker.kt
@@ -9,60 +9,56 @@ import kotlinx.coroutines.withContext
 import java.io.File
 
 public data class JvmFile(
-    override val path: String,
-    override val platformFile: File,
+	override val path: String,
+	override val platformFile: File,
 ) : MPFile<File>
 
 @Composable
 public actual fun FilePicker(
-    show: Boolean,
-    initialDirectory: String?,
-    fileExtensions: List<String>,
-    onFileSelected: FileSelected
+	show: Boolean,
+	initialDirectory: String?,
+	fileExtensions: List<String>,
+	onFileSelected: FileSelected
 ) {
-    val scope = rememberCoroutineScope()
-    LaunchedEffect(show) {
-        if (show) {
-            scope.launch(Dispatchers.Default) {
-                val fileFilter = if (fileExtensions.isNotEmpty()) {
-                    fileExtensions.joinToString(",")
-                } else {
-                    ""
-                }
+	LaunchedEffect(show) {
+		if (show) {
+			val fileFilter = if (fileExtensions.isNotEmpty()) {
+				fileExtensions.joinToString(",")
+			} else {
+				""
+			}
 
-                val initialDir = initialDirectory ?: System.getProperty("user.dir")
-                val filePath = FileChooser.chooseFile(
-                    initialDirectory = initialDir,
-                    fileExtensions = fileFilter
-                )
-                withContext(Dispatchers.Main) {
-                    if(filePath != null) {
-                        onFileSelected(JvmFile(filePath, File(filePath)))
-                    } else {
-                        onFileSelected(null)
-                    }
-                }
-            }
-        }
-    }
+			val initialDir = initialDirectory ?: System.getProperty("user.dir")
+			val filePath = FileChooser.chooseFile(
+				initialDirectory = initialDir,
+				fileExtensions = fileFilter
+			)
+			if (filePath != null) {
+				onFileSelected(JvmFile(filePath, File(filePath)))
+			} else {
+				onFileSelected(null)
+			}
+
+		}
+	}
 }
 
 @Composable
 public actual fun DirectoryPicker(
-    show: Boolean,
-    initialDirectory: String?,
-    onFileSelected: (String?) -> Unit
+	show: Boolean,
+	initialDirectory: String?,
+	onFileSelected: (String?) -> Unit
 ) {
-    val scope = rememberCoroutineScope()
-    LaunchedEffect(show) {
-        if (show) {
-            scope.launch(Dispatchers.Default) {
-                val initialDir = initialDirectory ?: System.getProperty("user.dir")
-                val fileChosen = FileChooser.chooseDirectory(initialDir)
-                withContext(Dispatchers.Main) {
-                    onFileSelected(fileChosen)
-                }
-            }
-        }
-    }
+	val scope = rememberCoroutineScope()
+	LaunchedEffect(show) {
+		if (show) {
+			scope.launch(Dispatchers.Default) {
+				val initialDir = initialDirectory ?: System.getProperty("user.dir")
+				val fileChosen = FileChooser.chooseDirectory(initialDir)
+				withContext(Dispatchers.Main) {
+					onFileSelected(fileChosen)
+				}
+			}
+		}
+	}
 }

--- a/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/DesktopFilePicker.kt
+++ b/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/DesktopFilePicker.kt
@@ -2,10 +2,6 @@ package com.darkrockstudios.libraries.mpfilepicker
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.rememberCoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.io.File
 
 public data class JvmFile(
@@ -49,16 +45,11 @@ public actual fun DirectoryPicker(
 	initialDirectory: String?,
 	onFileSelected: (String?) -> Unit
 ) {
-	val scope = rememberCoroutineScope()
 	LaunchedEffect(show) {
 		if (show) {
-			scope.launch(Dispatchers.Default) {
-				val initialDir = initialDirectory ?: System.getProperty("user.dir")
-				val fileChosen = FileChooser.chooseDirectory(initialDir)
-				withContext(Dispatchers.Main) {
-					onFileSelected(fileChosen)
-				}
-			}
+			val initialDir = initialDirectory ?: System.getProperty("user.dir")
+			val fileChosen = FileChooser.chooseDirectory(initialDir)
+			onFileSelected(fileChosen)
 		}
 	}
 }

--- a/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FileChooser.kt
+++ b/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FileChooser.kt
@@ -18,20 +18,20 @@ internal object FileChooser {
 		DIRECTORY
 	}
 
-	suspend fun chooseFile(
+	fun chooseFile(
 		initialDirectory: String = System.getProperty("user.dir"),
 		fileExtensions: String = ""
 	): String? {
 		return chooseFile(CallType.FILE, initialDirectory, fileExtensions)
 	}
 
-	suspend fun chooseDirectory(
+	fun chooseDirectory(
 		initialDirectory: String = System.getProperty("user.dir"),
 	): String? {
 		return chooseFile(CallType.DIRECTORY, initialDirectory)
 	}
 
-	private suspend fun chooseFile(
+	private fun chooseFile(
 		type: CallType,
 		initialDirectory: String,
 		fileExtensions: String = ""
@@ -49,7 +49,7 @@ internal object FileChooser {
 			.getOrNull()
 	}
 
-	private suspend fun chooseFileNative(
+	private fun chooseFileNative(
 		type: CallType,
 		initialDirectory: String,
 		fileExtension: String
@@ -57,7 +57,7 @@ internal object FileChooser {
 		return when (type) {
 			CallType.FILE -> {
 				MemoryStack.stackPush().use { stack ->
-					val filters = fileExtension.split(",")
+					val filters = if (fileExtension.isNotEmpty()) fileExtension.split(",") else emptyList()
 					val aFilterPatterns = stack.mallocPointer(filters.size)
 					filters.forEach {
 						aFilterPatterns.put(stack.UTF8("*.$it"))

--- a/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FileChooser.kt
+++ b/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FileChooser.kt
@@ -1,7 +1,5 @@
 package com.darkrockstudios.libraries.mpfilepicker
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.lwjgl.system.MemoryStack
 import org.lwjgl.util.tinyfd.TinyFileDialogs
 import org.lwjgl.util.tinyfd.TinyFileDialogs.tinyfd_selectFolderDialog
@@ -84,11 +82,11 @@ internal object FileChooser {
 		}
 	}
 
-	private suspend fun chooseFileSwing(
+	private fun chooseFileSwing(
 		type: CallType,
 		initialDirectory: String,
 		fileExtension: String
-	) = withContext(Dispatchers.IO) {
+	) {
 		UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
 
 		val chooser = when (type) {

--- a/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FileChooser.kt
+++ b/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FileChooser.kt
@@ -86,7 +86,7 @@ internal object FileChooser {
 		type: CallType,
 		initialDirectory: String,
 		fileExtension: String
-	) {
+	): String? {
 		UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
 
 		val chooser = when (type) {
@@ -107,7 +107,7 @@ internal object FileChooser {
 			}
 		}
 
-		when (val code = chooser.showOpenDialog(null)) {
+		return when (val code = chooser.showOpenDialog(null)) {
 			JFileChooser.APPROVE_OPTION -> chooser.selectedFile.absolutePath
 			JFileChooser.CANCEL_OPTION -> null
 			JFileChooser.ERROR_OPTION -> error("An error occurred while executing JFileChooser::showOpenDialog")


### PR DESCRIPTION
fixes https://github.com/Wavesonics/compose-multiplatform-file-picker/issues/30

I did it according to https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/fd6572d5b61513c81932082c85969b501af6d828/src/main/java/appeng/client/guidebook/command/GuidebookStructureCommands.java#L245 and https://github.com/LWJGL/lwjgl3/blob/a29ef793b91aa6275604fdb73f5604e6e3bbe578/modules/samples/src/test/java/org/lwjgl/demo/util/tinyfd/HelloTinyFD.java#L66

Im not 100% sure that my PR is correct, but it no longer crashes on MacOS, have not tested it on Windows yet. Also I removed `withContext(Dispatchers.IO)`, because it is unclear why it was in the first place, on https://www.lwjgl.org/guide they say to use `-XstartOnFirstThread`, which seems to be main thread, so I guess we can also remove it.

There is also 2 usages of `withContext`, they also seem redundant. Should I remove them?