### PR TITLE
Make desktop (`jvm` module) file pickers modal

### DIFF
--- a/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/DesktopFilePicker.kt
+++ b/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/DesktopFilePicker.kt
@@ -23,10 +23,7 @@ public actual fun FilePicker(
 	Picker(show) {
 		val fileFilter = fileExtensions.joinToString(separator = ",")
 		val initialDir = initialDirectory ?: System.getProperty("user.dir")
-		val filePath = FileChooser.chooseFile(
-			initialDirectory = initialDir,
-			fileExtensions = fileFilter
-		)
+		val filePath = FileChooser.chooseFile(initialDir, fileFilter)
 		val mpFile = filePath?.let { JvmFile(filePath, File(filePath)) }
 		onFileSelected(mpFile)
 	}
@@ -44,7 +41,6 @@ public actual fun DirectoryPicker(
 		onFileSelected(dirPath)
 	}
 }
-
 
 /**
  * Hack to make [FilePicker] and [DirectoryPicker] modal.


### PR DESCRIPTION
I investigated various ways to make the file pickers modal, but every "pretty" approach has failed. So I created this simple but fully working hack. Basically, every time we open a file picker, we also open a zero-sized "ghost" `Dialog` (which is modal).

This approach has been tested on Windows and Linux (both debug and release). I currently don't have the opportunity to test this approach on macOS as well. Hope someone confirms that it works there too. Also, I'm pretty sure that this approach can be used in the `macosX64Main` module as well.


Fixes #23.