### PR TITLE
Fix broken FilePicker parameter in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To show the dialog, simply set the boolean state to true via a button or what ev
 var showFilePicker by remember { mutableStateOf(false) }
 
 val fileType = listOf("jpg", "png")
-FilePicker(show, fileExtensions = fileType) { file ->
+FilePicker(show = showFilePicker, fileExtensions = fileType) { file ->
     showFilePicker = false
     // do something with the file
 }


### PR DESCRIPTION
Rectify the errors in the FilePicker example within the README.md file.