### PR TITLE
A better way to disable Github Action

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -1,7 +1,8 @@
 name: Run checks
-# Temporarily disable due to https://github.com/Wavesonics/compose-multiplatform-file-picker/issues/94
-# on:
-#   pull_request
+
+on:
+  pull_request
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Previously I caused syntax errors so Run Checks workflow would not run, but they still show up on Actions tab and show syntax errors, for example: https://github.com/Wavesonics/compose-multiplatform-file-picker/actions/runs/7185212468

Instead I will disable them with the right way :D
https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow