### PR TITLE
Fix library crash while getting byteArray for `content` AndroidFile scheme

### DIFF
--- a/mpfilepicker/src/androidMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/AndroidFilePicker.kt
+++ b/mpfilepicker/src/androidMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/AndroidFilePicker.kt
@@ -1,18 +1,26 @@
 package com.darkrockstudios.libraries.mpfilepicker
 
+import android.content.Context
 import android.net.Uri
 import android.webkit.MimeTypeMap
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toFile
 
 public data class AndroidFile(
 	override val path: String,
 	override val platformFile: Uri,
+	private val context: Context,
 ) : MPFile<Uri> {
-	override suspend fun getFileByteArray(): ByteArray = platformFile.toFile().readBytes()
+	override suspend fun getFileByteArray(): ByteArray {
+		return context.contentResolver
+			.openInputStream(platformFile)
+			.use { inputStream -> inputStream?.readBytes() }
+			?: platformFile.toFile().readBytes()
+	}
 }
 
 @Composable
@@ -23,9 +31,10 @@ public actual fun FilePicker(
 	title: String?,
 	onFileSelected: FileSelected
 ) {
+	val context = LocalContext.current
 	val launcher = rememberLauncherForActivityResult(contract = ActivityResultContracts.OpenDocument()) { result ->
 		if (result != null) {
-			onFileSelected(AndroidFile(result.toString(), result))
+			onFileSelected(AndroidFile(result.toString(), result, context))
 		} else {
 			onFileSelected(null)
 		}
@@ -54,13 +63,14 @@ public actual fun MultipleFilePicker(
 	title: String?,
 	onFileSelected: FilesSelected
 ) {
+	val context = LocalContext.current
 	val launcher = rememberLauncherForActivityResult(
 		contract = ActivityResultContracts.OpenMultipleDocuments()
 	) { result ->
 
 		val files = result.mapNotNull { uri ->
 			uri.path?.let {path ->
-				AndroidFile(path, uri)
+				AndroidFile(path, uri, context)
 			}
 		}
 


### PR DESCRIPTION
This PR fixes the library crash when the user tries to extract `ByteArray` out of a selected file that has the fileScheme of type `content` (`content://---`) instead of `file` (`file://---`).

## Demo (before fix)

https://github.com/Wavesonics/compose-multiplatform-file-picker/assets/46640516/7a78f66e-682b-4405-a9b9-c92771b98e28

## Demo (after fix)

https://github.com/Wavesonics/compose-multiplatform-file-picker/assets/46640516/5089a873-8096-40b7-b45d-b64767c986ea
