### PR TITLE
Add getBytes() method to PlatformFile

### DIFF
--- a/mpfilepicker/src/commonMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.kt
+++ b/mpfilepicker/src/commonMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.kt
@@ -2,14 +2,16 @@ package com.darkrockstudios.libraries.mpfilepicker
 
 import androidx.compose.runtime.Composable
 
-public expect class PlatformFile
+expect class PlatformFile {
+	suspend fun getBytes(): ByteArray?
+}
 
-public typealias FileSelected = (PlatformFile?) -> Unit
+typealias FileSelected = (PlatformFile?) -> Unit
 
-public typealias FilesSelected = (List<PlatformFile>?) -> Unit
+typealias FilesSelected = (List<PlatformFile>?) -> Unit
 
 @Composable
-public expect fun FilePicker(
+expect fun FilePicker(
 	show: Boolean,
 	initialDirectory: String? = null,
 	fileExtensions: List<String> = emptyList(),
@@ -18,7 +20,7 @@ public expect fun FilePicker(
 )
 
 @Composable
-public expect fun MultipleFilePicker(
+expect fun MultipleFilePicker(
 	show: Boolean,
 	initialDirectory: String? = null,
 	fileExtensions: List<String> = emptyList(),
@@ -27,7 +29,7 @@ public expect fun MultipleFilePicker(
 )
 
 @Composable
-public expect fun DirectoryPicker(
+expect fun DirectoryPicker(
 	show: Boolean,
 	initialDirectory: String? = null,
 	title: String? = null,

--- a/mpfilepicker/src/iosMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.ios.kt
+++ b/mpfilepicker/src/iosMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.ios.kt
@@ -10,10 +10,10 @@ import platform.Foundation.NSData
 import platform.Foundation.NSURL
 import platform.posix.memcpy
 
-public actual data class PlatformFile(
+actual data class PlatformFile(
 	val nsUrl: NSURL,
 ) {
-	public val bytes: ByteArray =
+	actual suspend fun getBytes(): ByteArray? =
 		nsUrl.dataRepresentation.toByteArray()
 
 	@OptIn(ExperimentalForeignApi::class)
@@ -25,7 +25,7 @@ public actual data class PlatformFile(
 }
 
 @Composable
-public actual fun FilePicker(
+actual fun FilePicker(
 	show: Boolean,
 	initialDirectory: String?,
 	fileExtensions: List<String>,
@@ -50,7 +50,7 @@ public actual fun FilePicker(
 }
 
 @Composable
-public actual fun MultipleFilePicker(
+actual fun MultipleFilePicker(
 	show: Boolean,
 	initialDirectory: String?,
 	fileExtensions: List<String>,
@@ -73,7 +73,7 @@ public actual fun MultipleFilePicker(
 }
 
 @Composable
-public actual fun DirectoryPicker(
+actual fun DirectoryPicker(
 	show: Boolean,
 	initialDirectory: String?,
 	title: String?,

--- a/mpfilepicker/src/jsMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.js.kt
+++ b/mpfilepicker/src/jsMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.js.kt
@@ -15,12 +15,15 @@ import org.w3c.files.FileReader
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
-public actual data class PlatformFile(
+actual data class PlatformFile(
 	val file: File,
-)
+) {
+	actual suspend fun getBytes(): ByteArray? =
+		readFileAsByteArray(file)
+}
 
 @Composable
-public actual fun FilePicker(
+actual fun FilePicker(
 	show: Boolean,
 	initialDirectory: String?,
 	fileExtensions: List<String>,
@@ -30,7 +33,8 @@ public actual fun FilePicker(
 	LaunchedEffect(show) {
 		if (show) {
 			val fixedExtensions = fileExtensions.map { ".$it" }
-			val file: List<File> = document.selectFilesFromDisk(fixedExtensions.joinToString(","), false)
+			val file: List<File> =
+				document.selectFilesFromDisk(fixedExtensions.joinToString(","), false)
 			val platformFile = PlatformFile(file.first())
 			onFileSelected(platformFile)
 		}
@@ -38,7 +42,7 @@ public actual fun FilePicker(
 }
 
 @Composable
-public actual fun MultipleFilePicker(
+actual fun MultipleFilePicker(
 	show: Boolean,
 	initialDirectory: String?,
 	fileExtensions: List<String>,
@@ -48,7 +52,8 @@ public actual fun MultipleFilePicker(
 	LaunchedEffect(show) {
 		if (show) {
 			val fixedExtensions = fileExtensions.map { ".$it" }
-			val files: List<File> = document.selectFilesFromDisk(fixedExtensions.joinToString(","), true)
+			val files: List<File> =
+				document.selectFilesFromDisk(fixedExtensions.joinToString(","), true)
 			val webFiles = files.map { PlatformFile(it) }
 			onFileSelected(webFiles)
 		}
@@ -56,7 +61,7 @@ public actual fun MultipleFilePicker(
 }
 
 @Composable
-public actual fun DirectoryPicker(
+actual fun DirectoryPicker(
 	show: Boolean,
 	initialDirectory: String?,
 	title: String?,
@@ -87,7 +92,7 @@ private suspend fun Document.selectFilesFromDisk(
 	tempInput.remove()
 }
 
-public suspend fun readFileAsText(file: File): String = suspendCoroutine {
+suspend fun readFileAsText(file: File): String = suspendCoroutine {
 	val reader = FileReader()
 	reader.onload = { loadEvt ->
 		val content = loadEvt.target.asDynamic().result as String
@@ -96,15 +101,15 @@ public suspend fun readFileAsText(file: File): String = suspendCoroutine {
 	reader.readAsText(file, "UTF-8")
 }
 
-public suspend fun readFileAsByteArray(file: File): ByteArray = suspendCoroutine {
+suspend fun readFileAsByteArray(file: File): ByteArray = suspendCoroutine {
 	val reader = FileReader()
-	reader.onload = {loadEvt ->
+	reader.onload = { loadEvt ->
 		val content = loadEvt.target.asDynamic().result as ArrayBuffer
 		val array = Uint8Array(content)
 		val fileByteArray = ByteArray(array.length)
-			for (i in 0 until array.length) {
-				fileByteArray[i] = array[i]
-			}
+		for (i in 0 until array.length) {
+			fileByteArray[i] = array[i]
+		}
 		it.resumeWith(Result.success(fileByteArray))
 	}
 	reader.readAsArrayBuffer(file)

--- a/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.desktop.kt
+++ b/mpfilepicker/src/jvmMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.desktop.kt
@@ -4,12 +4,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import java.io.File
 
-public actual data class PlatformFile(
+actual data class PlatformFile(
 	val file: File,
-)
+) {
+	actual suspend fun getBytes(): ByteArray? =
+		file.readBytes()
+}
 
 @Composable
-public actual fun FilePicker(
+actual fun FilePicker(
 	show: Boolean,
 	initialDirectory: String?,
 	fileExtensions: List<String>,
@@ -43,7 +46,7 @@ public actual fun FilePicker(
 }
 
 @Composable
-public actual fun MultipleFilePicker(
+actual fun MultipleFilePicker(
 	show: Boolean,
 	initialDirectory: String?,
 	fileExtensions: List<String>,
@@ -75,7 +78,7 @@ public actual fun MultipleFilePicker(
 }
 
 @Composable
-public actual fun DirectoryPicker(
+actual fun DirectoryPicker(
 	show: Boolean,
 	initialDirectory: String?,
 	title: String?,

--- a/mpfilepicker/src/macosX64Main/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.macos.kt
+++ b/mpfilepicker/src/macosX64Main/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.macos.kt
@@ -11,10 +11,10 @@ import platform.Foundation.NSData
 import platform.Foundation.NSURL
 import platform.posix.memcpy
 
-public actual data class PlatformFile(
+actual data class PlatformFile(
 	val nsUrl: NSURL,
 ) {
-	public val bytes: ByteArray =
+	actual suspend fun getBytes(): ByteArray? =
 		nsUrl.dataRepresentation.toByteArray()
 
 	@OptIn(ExperimentalForeignApi::class)
@@ -26,7 +26,7 @@ public actual data class PlatformFile(
 }
 
 @Composable
-public actual fun FilePicker(
+actual fun FilePicker(
 	show: Boolean,
 	initialDirectory: String?,
 	fileExtensions: List<String>,
@@ -61,7 +61,7 @@ public actual fun FilePicker(
 }
 
 @Composable
-public actual fun MultipleFilePicker(
+actual fun MultipleFilePicker(
 	show: Boolean,
 	initialDirectory: String?,
 	fileExtensions: List<String>,
@@ -94,7 +94,7 @@ public actual fun MultipleFilePicker(
 }
 
 @Composable
-public actual fun DirectoryPicker(
+actual fun DirectoryPicker(
 	show: Boolean,
 	initialDirectory: String?,
 	title: String?,


### PR DESCRIPTION
I added back the useful method `getBytes()` that was here before to `PlatFormFile` with the exact same logic as before, except for Android where I added the fix from @shubhamsinghshubham777 proposed in this PR https://github.com/Wavesonics/compose-multiplatform-file-picker/pull/104