### PR TITLE
Add support for wasmJs targets

### DIFF
--- a/.run/WASM-Web Example.run.xml
+++ b/.run/WASM-Web Example.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="WASM-Web Example" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/examples/web" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":examples:web-wasm:wasmJsBrowserDevelopmentRun" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/examples/ios/ios.podspec
+++ b/examples/ios/ios.podspec
@@ -9,8 +9,8 @@ Pod::Spec.new do |spec|
     spec.vendored_frameworks      = 'build/cocoapods/framework/ios.framework'
     spec.libraries                = 'c++'
     spec.ios.deployment_target = '14.1'
-                
-                
+
+
     if !Dir.exist?('build/cocoapods/framework/ios.framework') || Dir.empty?('build/cocoapods/framework/ios.framework')
         raise "
 
@@ -21,12 +21,12 @@ Pod::Spec.new do |spec|
 
         Alternatively, proper pod installation is performed during Gradle sync in the IDE (if Podfile location is set)"
     end
-                
+
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':examples:ios',
         'PRODUCT_MODULE_NAME' => 'ios',
     }
-                
+
     spec.script_phases = [
         {
             :name => 'Build ios',

--- a/examples/web-wasm/build.gradle.kts
+++ b/examples/web-wasm/build.gradle.kts
@@ -1,0 +1,32 @@
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+
+plugins {
+	alias(libs.plugins.kotlinMultiplatform)
+	alias(libs.plugins.jetbrainsCompose)
+}
+
+kotlin {
+	@OptIn(ExperimentalWasmDsl::class)
+	wasmJs {
+		browser {
+			commonWebpackConfig {
+				outputFileName = "composeApp.js"
+			}
+		}
+		binaries.executable()
+	}
+	sourceSets {
+		val wasmJsMain by getting {
+			dependencies {
+				implementation(compose.runtime)
+				implementation(compose.foundation)
+				implementation(compose.material3)
+				implementation(project(":mpfilepicker"))
+			}
+		}
+	}
+}
+
+compose.experimental {
+	web.application {}
+}

--- a/examples/web-wasm/src/wasmJsMain/kotlin/main.kt
+++ b/examples/web-wasm/src/wasmJsMain/kotlin/main.kt
@@ -1,0 +1,155 @@
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.CanvasBasedWindow
+import com.darkrockstudios.libraries.mpfilepicker.*
+import kotlinx.coroutines.launch
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+	CanvasBasedWindow(canvasElementId = "ComposeTarget", title = "") { ExampleView() }
+}
+
+@OptIn(ExperimentalEncodingApi::class)
+@Composable
+fun ExampleView() {
+	val scope = rememberCoroutineScope()
+
+	var pickerVisible by remember { mutableStateOf(false) }
+	var multipickerVisible by remember { mutableStateOf(false) }
+
+	var fileSelected by remember { mutableStateOf(false) }
+	val fileNames = remember { mutableStateListOf<String>() }
+	val fileContents = remember { mutableStateListOf<String>() }
+	val fileContentsRaw = remember { mutableStateListOf<String>() }
+
+	suspend fun addFile(
+		file: PlatformFile,
+	) {
+		val content = readFileAsByteArray(file.file)
+
+		fileNames.add(file.file.name)
+		fileContents.add(content.decodeToString())
+		fileContentsRaw.add(Base64.encode(content))
+	}
+
+	FilePicker(
+		pickerVisible,
+	) {
+		pickerVisible = false
+		fileNames.clear()
+		fileContents.clear()
+
+		if (it != null) {
+			fileSelected = true
+
+			scope.launch {
+				addFile(it)
+			}
+		} else {
+			fileSelected = false
+		}
+	}
+
+	MultipleFilePicker(
+		multipickerVisible,
+	) {
+		multipickerVisible = false
+		fileNames.clear()
+		fileContents.clear()
+
+		if (it?.isNotEmpty() == true) {
+			fileSelected = true
+
+			scope.launch {
+				it.forEach { file ->
+					addFile(file)
+				}
+			}
+		} else {
+			fileSelected = false
+		}
+	}
+
+	MaterialTheme {
+		Column(modifier = Modifier.fillMaxSize()) {
+			Row(
+				modifier = Modifier.padding(10.dp),
+				horizontalArrangement = Arrangement.spacedBy(10.dp)
+			) {
+				// Button to open the file picker
+				Button(onClick = {
+					pickerVisible = true
+					multipickerVisible = false
+				}) {
+					Text("Open File Picker")
+				}
+
+				// Button to open the multiple file picker
+				Button(onClick = {
+					pickerVisible = false
+					multipickerVisible = true
+				}) {
+					Text("Open Multi-File Picker")
+				}
+			}
+
+			AnimatedVisibility(fileSelected) {
+				Text("Selected Files:")
+			}
+			AnimatedVisibility(!fileSelected) {
+				Text("No files selected")
+			}
+
+			LazyColumn(contentPadding = PaddingValues(10.dp)) {
+				fileNames.forEachIndexed { idx, fileName ->
+					item {
+						Card {
+							Column {
+								Text("File: $fileName")
+								if (fileContents.getOrNull(idx)?.contains('\uFFFD') == false) {
+									Text("Content:")
+									FileContent(fileContents.getOrNull(idx))
+								}
+
+								Text("Raw Content (Base64):")
+								FileContent(fileContentsRaw.getOrNull(idx))
+							}
+						}
+						Spacer(modifier = Modifier.height(10.dp))
+					}
+				}
+			}
+		}
+	}
+}
+
+@Composable
+private fun FileContent(fileContent: String?) {
+	Text(
+		fileContent ?: "N/A",
+		modifier = Modifier
+			.background(
+				Color.LightGray.copy(alpha = 0.5f),
+				MaterialTheme.shapes.medium
+			)
+			.width(1200.dp)
+			.padding(5.dp),
+		fontFamily = FontFamily.Monospace,
+		color = Color.Black,
+		overflow = TextOverflow.Ellipsis,
+		softWrap = true
+	)
+}
+

--- a/examples/web-wasm/src/wasmJsMain/resources/index.html
+++ b/examples/web-wasm/src/wasmJsMain/resources/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Compose App</title>
+	<script type="application/javascript" src="skiko.js"></script>
+	<script type="application/javascript" src="composeApp.js"></script>
+</head>
+<body>
+<canvas id="ComposeTarget"></canvas>
+</body>
+</html>

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,5 @@ android.useAndroidX=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
+org.jetbrains.compose.experimental.wasm.enabled=true
 org.gradle.jvmargs=-Xmx4096m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.2.1"
-compose-plugin = "1.5.11"
-kotlin = "1.9.21"
+compose-plugin = "1.6.0-beta02"
+kotlin = "1.9.22"
 library = "3.1.0"
 android-compile-sdk = "34"
 android-target-sdk = "34"

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -70,6 +70,11 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@js-joda/core@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
+  integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"

--- a/mpfilepicker/build.gradle.kts
+++ b/mpfilepicker/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 import java.net.URI
 
 plugins {
@@ -30,6 +31,13 @@ kotlin {
 	}
 
 	js(IR) {
+		browser()
+		binaries.executable()
+	}
+
+	@OptIn(ExperimentalWasmDsl::class)
+	wasmJs {
+		moduleName = "mpfilepicker"
 		browser()
 		binaries.executable()
 	}
@@ -90,6 +98,7 @@ kotlin {
 		}
 		val jvmTest by getting
 		val jsMain by getting
+		val wasmJsMain by getting
 	}
 
 	@Suppress("OPT_IN_USAGE")
@@ -174,4 +183,8 @@ android {
 		sourceCompatibility = JavaVersion.VERSION_17
 		targetCompatibility = JavaVersion.VERSION_17
 	}
+}
+
+compose.experimental {
+	web.application {}
 }

--- a/mpfilepicker/src/wasmJsMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.wasm.kt
+++ b/mpfilepicker/src/wasmJsMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.wasm.kt
@@ -1,0 +1,125 @@
+package com.darkrockstudios.libraries.mpfilepicker
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.browser.document
+import org.khronos.webgl.ArrayBuffer
+import org.khronos.webgl.Uint8Array
+import org.khronos.webgl.get
+import org.w3c.dom.Document
+import org.w3c.dom.HTMLInputElement
+import org.w3c.dom.asList
+import org.w3c.files.File
+import org.w3c.files.FileReader
+import kotlin.coroutines.*
+
+public actual data class PlatformFile(
+	val file: File,
+)
+
+@Composable
+public actual fun FilePicker(
+	show: Boolean,
+	initialDirectory: String?,
+	fileExtensions: List<String>,
+	title: String?,
+	onFileSelected: FileSelected,
+) {
+	LaunchedEffect(show) {
+		if (show) {
+			val fixedExtensions = fileExtensions.map { ".$it" }
+			val file: List<File> = document.selectFilesFromDisk(fixedExtensions.joinToString(","), false)
+			val platformFile = PlatformFile(file.first())
+			onFileSelected(platformFile)
+		}
+	}
+}
+
+@Composable
+public actual fun MultipleFilePicker(
+	show: Boolean,
+	initialDirectory: String?,
+	fileExtensions: List<String>,
+	title: String?,
+	onFileSelected: FilesSelected
+) {
+	LaunchedEffect(show) {
+		if (show) {
+			val fixedExtensions = fileExtensions.map { ".$it" }
+			val files: List<File> = document.selectFilesFromDisk(fixedExtensions.joinToString(","), true)
+			val webFiles = files.map { PlatformFile(it) }
+			onFileSelected(webFiles)
+		}
+	}
+}
+
+@Composable
+public actual fun DirectoryPicker(
+	show: Boolean,
+	initialDirectory: String?,
+	title: String?,
+	onFileSelected: (String?) -> Unit,
+) {
+	// in a browser we can not pick directories
+	throw NotImplementedError("DirectoryPicker is not supported on the web")
+}
+
+private suspend fun Document.selectFilesFromDisk(
+	accept: String,
+	isMultiple: Boolean
+): List<File> = suspendCoroutine {
+	val tempInput = (createElement("input") as HTMLInputElement).apply {
+		type = "file"
+		style.display = "none"
+		this.accept = accept
+		multiple = isMultiple
+	}
+
+	tempInput.onchange = { changeEvt ->
+		try {
+			val inputElement = changeEvt.target as HTMLInputElement
+			val files = inputElement.files?.asList() ?: emptyList()
+			it.resume(files)
+		} catch (e: Throwable) {
+			it.resumeWithException(e)
+		}
+	}
+
+	body!!.append(tempInput)
+	tempInput.click()
+	tempInput.remove()
+}
+
+public suspend fun readFileAsText(file: File): String = suspendCoroutine {
+	val reader = FileReader()
+	reader.onload = { loadEvt ->
+		try {
+			val eventFileReader = loadEvt.target?.let { it as FileReader }
+			val content = eventFileReader!!.result?.unsafeCast<JsString>()!!
+			it.resume(content.toString())
+		} catch (e: Throwable) {
+			it.resumeWithException(e)
+		}
+	}
+	reader.readAsText(file, "UTF-8")
+}
+
+public suspend fun readFileAsByteArray(file: File): ByteArray = suspendCoroutine {
+	val reader = FileReader()
+	reader.onload = {loadEvt ->
+		try {
+			val eventFileReader = loadEvt.target?.let { it as FileReader }!!
+			val content = eventFileReader.result as ArrayBuffer
+			val array = Uint8Array(content)
+
+			val fileByteArray = ByteArray(array.length)
+			for (i in 0 until array.length) {
+				fileByteArray[i] = array[i]
+			}
+			it.resumeWith(Result.success(fileByteArray))
+		} catch (e: Throwable) {
+			it.resumeWithException(e)
+		}
+	}
+	reader.readAsArrayBuffer(file)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ rootProject.name = "MultiplatformFilePicker"
 include(":mpfilepicker")
 include(":examples:android")
 include(":examples:jvm")
+include(":examples:web-wasm")
 include(":examples:web")
 include(":examples:macosX64")
 include(":examples:ios")


### PR DESCRIPTION
Hi,

I tried to add support for wasmJs since I wanted to use it for one of my projects.
Unfortunately I had to raise the kotlin and compose versions to enable support for these targets.

If you do not want to merge this PR because of these version changes, it could be used in the future when the wasmJs-target is out of alpha status.

The implementation is largely based on the implementation for the js-target (+ some changes to make the type-checker happy).