### PR TITLE
👷 In CI, only build mpfilepicker module and use new Mac M1 runner

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Build project
-        run: ./gradlew build
+        run: ./gradlew :mpfilepicker:build
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- [x] Build only mpfilepicker module with `./gradlew :mpfilepicker:build`
- [x] Use M1 macOS for better efficiency: [source](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/)

