### PR TITLE
Include hint about adding jdk.unsupported to the native distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ A multiplatform compose widget for picking files with each platform's Native Fil
 implementation("com.darkrockstudios:mpfilepicker:3.1.0")
 ```
 
+For use in compose desktops native distribution, include this in your build.gradle.kts as well:
+```build.gradle.kts
+compose.desktop.application {
+    nativeDistributions {
+        modules("jdk.unsupported")
+    }
+}
+```
+
 ## How to use
 
 In your shared jetbrains compose multiplatform code, add one of the following.


### PR DESCRIPTION
Fixes https://github.com/Wavesonics/compose-multiplatform-file-picker/issues/87